### PR TITLE
Hacky fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -1173,7 +1173,7 @@ func genProgramBoilerplate(idl IDL) (*File, error) {
 								for _, doc := range instruction.Docs {
 									ins.Comment(doc).Line()
 								}
-								toBeHashed := ToSnake(instruction.Name)
+								toBeHashed := ToSnakeNoNumbers(instruction.Name)
 								if GetConfig().Debug {
 									ins.Comment(Sf(`hash("%s:%s")`, bin.SIGHASH_GLOBAL_NAMESPACE, toBeHashed)).Line()
 								}
@@ -1358,7 +1358,7 @@ func genProgramBoilerplate(idl IDL) (*File, error) {
 									BlockFunc(func(variantBlock *Group) {
 										for _, instruction := range idl.Instructions {
 											// NOTE: using `ToSnake` here (necessary for sighash computing from instruction name)
-											insName := ToSnake(instruction.Name)
+											insName := ToSnakeNoNumbers(instruction.Name)
 											insExportedName := ToCamel(instruction.Name)
 											variantBlock.Block(
 												List(Lit(insName), Parens(Op("*").Id(insExportedName)).Parens(Nil())).Op(","),
@@ -1684,4 +1684,69 @@ func treeFormatAccountName(name string) string {
 		}
 	}
 	return cleanedName
+}
+
+// ToSnake converts a string to snake_case
+func ToSnakeNoNumbers(s string) string {
+	return ToDelimitedNoNumbers(s, '_')
+}
+
+// ToDelimited converts a string to delimited.snake.case
+// (in this case `delimiter = '.'`)
+func ToDelimitedNoNumbers(s string, delimiter uint8) string {
+	return ToScreamingDelimitedNumberFree(s, delimiter, 0, false)
+}
+
+// ToScreamingDelimited converts a string to SCREAMING.DELIMITED.SNAKE.CASE
+// (in this case `delimiter = '.'; screaming = true`)
+// or delimited.snake.case
+// (in this case `delimiter = '.'; screaming = false`)
+func ToScreamingDelimitedNumberFree(s string, delimiter uint8, ignore uint8, screaming bool) string {
+	s = strings.TrimSpace(s)
+	n := strings.Builder{}
+	n.Grow(len(s) + 2) // nominal 2 bytes of extra space for inserted delimiters
+	for i, v := range []byte(s) {
+		vIsCap := v >= 'A' && v <= 'Z'
+		vIsLow := v >= 'a' && v <= 'z'
+		if vIsLow && screaming {
+			v += 'A'
+			v -= 'a'
+		} else if vIsCap && !screaming {
+			v += 'a'
+			v -= 'A'
+		}
+
+		// treat acronyms as words, eg for JSONData -> JSON is a whole word
+		if i+1 < len(s) {
+			next := s[i+1]
+			vIsNum := v >= '0' && v <= '9'
+			nextIsCap := next >= 'A' && next <= 'Z'
+			nextIsLow := next >= 'a' && next <= 'z'
+			nextIsNum := next >= '0' && next <= '9'
+			// add underscore if next letter case type is changed
+			if (vIsCap && (nextIsLow)) || (vIsLow && (nextIsCap )) || (vIsNum && (nextIsCap || nextIsLow)) {
+				if prevIgnore := ignore > 0 && i > 0 && s[i-1] == ignore; !prevIgnore {
+					if vIsCap && nextIsLow {
+						if prevIsCap := i > 0 && s[i-1] >= 'A' && s[i-1] <= 'Z'; prevIsCap {
+							n.WriteByte(delimiter)
+						}
+					}
+					n.WriteByte(v)
+					if vIsLow || vIsNum || nextIsNum {
+						n.WriteByte(delimiter)
+					}
+					continue
+				}
+			}
+		}
+
+		if (v == '_' || v == ' ' || v == '-' || v == '.' || v == '/' || v == '\\' || v == '@') && uint8(v) != ignore {
+			// replace space/underscore/hyphen with delimiter
+			n.WriteByte(delimiter)
+		} else {
+			n.WriteByte(v)
+		}
+	}
+
+	return n.String()
 }


### PR DESCRIPTION
If a method ends in a number "doSomething2" then the `AnchorTypeIDEncoding` is wrong as it treats it as do_something_2 instead of the required `do_something2`

I only needed to generate once so I didn't really solve this correctly as it's across multiple repos