### PR TITLE
Instruction decoders must read and check discriminator

### DIFF
--- a/generator/instructions.go
+++ b/generator/instructions.go
@@ -562,10 +562,17 @@ func (g *Generator) gen_instructionType(instruction idl.IdlInstruction) (Code, e
 				block.Comment("Read the discriminator and check it against the expected value:")
 				block.List(Id("discriminator"), Err()).Op(":=").Id("decoder").Dot("ReadDiscriminator").Call()
 				block.If(Err().Op("!=").Nil()).Block(
-					Return(Qual("fmt", "Errorf").Call(Lit("failed to read instruction discriminator: %w"), Err())),
+					Return(Qual("fmt", "Errorf").Call(Lit("failed to read instruction discriminator for %s: %w"), Lit(typeName), Err())),
 				)
 				block.If(Id("discriminator").Op("!=").Id(FormatInstructionDiscriminatorName(tools.ToCamelUpper(instruction.Name)))).Block(
-					Return(Qual("fmt", "Errorf").Call(Lit("instruction discriminator mismatch: expected %s, got %s"), Id(FormatInstructionDiscriminatorName(tools.ToCamelUpper(instruction.Name))), Id("discriminator"))),
+					Return(
+						Qual("fmt", "Errorf").Call(
+							Lit("instruction discriminator mismatch for %s: expected %s, got %s"),
+							Lit(typeName),
+							Id(FormatInstructionDiscriminatorName(tools.ToCamelUpper(instruction.Name))),
+							Id("discriminator"),
+						),
+					),
 				)
 			}
 			for _, arg := range instruction.Args {


### PR DESCRIPTION
@allen-moonshot 

See note comments:

Before:

```go
func (obj *InitInstruction) UnmarshalWithDecoder(decoder *binary.Decoder) error {
	// NOTE: NOTICE THAT THERE IS NO DISCRIMINATOR READING OR VALIDATION
	var err error
	// Deserialize `Params`:
	err = decoder.Decode(&obj.Params) // NOTE: THE TYPE OF `Params` IS `InitParams` WHICH DOES NOT REQUIRE A DISCRIMINATOR
	if err != nil {
		return err
	}
	return nil
}


// ParseInstruction parses instruction data and optionally populates accounts // If accountIndicesData is nil or empty, accounts will not be populated
func ParseInstruction(instructionData []byte, accountIndicesData []byte, accountKeys []solanago.PublicKey) (Instruction, error) {
	// Validate inputs
	if len(instructionData) < 8 {
		return nil, fmt.Errorf("instruction data too short: expected at least 8 bytes, got %d", len(instructionData))
	}
	// Extract discriminator
	discriminator := [8]byte{}
	copy(discriminator[:], instructionData[0:8]) // NOTE: THE DISCRIMINATOR IS STILL THE FIRST 8 BYTES
	// Parse based on discriminator
	switch discriminator {
	case Instruction_Init:
		instruction := new(InitInstruction)
		decoder := binary.NewBorshDecoder(instructionData) // NOTE: THE DISCRIMINATOR + DATA IS PASSED TO THE DECODER, BUT THE DECODER WILL INTERPRET THE FIRST 8 BYTES AS SOMETHING ELSE
		err := instruction.UnmarshalWithDecoder(decoder)
		if err != nil {
			return nil, fmt.Errorf("failed to unmarshal instruction as InitInstruction: %w", err)
		}
		if accountIndicesData != nil && len(accountIndicesData) > 0 {
			indices, err := instruction.UnmarshalAccountIndices(accountIndicesData)
			if err != nil {
				return nil, fmt.Errorf("failed to unmarshal account indices: %w", err)
			}
			err = instruction.PopulateFromAccountIndices(indices, accountKeys)
			if err != nil {
				return nil, fmt.Errorf("failed to populate accounts: %w", err)
			}
		}
		return instruction, nil
```


After:

```go
// UnmarshalWithDecoder unmarshals the InitInstruction from Borsh-encoded bytes prefixed with its discriminator.
func (obj *InitInstruction) UnmarshalWithDecoder(decoder *binary.Decoder) error {
	var err error
	// Read the discriminator and check it against the expected value:
	discriminator, err := decoder.ReadDiscriminator() // NOTE: READ AND VALIDATE THE DISCRIMINATOR, SO THAT THEN THE ACTUAL DATA CAN BE PARSED
	if err != nil {
		return fmt.Errorf("failed to read instruction discriminator: %w", err)
	}
	if discriminator != Instruction_Init {
		return fmt.Errorf("instruction discriminator mismatch: expected %s, got %s", Instruction_Init, discriminator)
	}
	// Deserialize `Params`:
	err = decoder.Decode(&obj.Params)
	if err != nil {
		return err
	}
	return nil
}

// ParseInstruction parses instruction data and optionally populates accounts
// If accountIndicesData is nil or empty, accounts will not be populated
func ParseInstruction(instructionData []byte, accountIndicesData []byte, accountKeys []solanago.PublicKey) (Instruction, error) {
	// Validate inputs
	if len(instructionData) < 8 {
		return nil, fmt.Errorf("instruction data too short: expected at least 8 bytes, got %d", len(instructionData))
	}
	// Extract discriminator
	discriminator := [8]byte{}
	copy(discriminator[:], instructionData[0:8]) // NOTE: SEE HOW THE DISCRIMINATOR IS STILL THE FIRST 8 BYTES
	// Parse based on discriminator
	switch discriminator {
	case Instruction_Init:
		instruction := new(InitInstruction)
		decoder := binary.NewBorshDecoder(instructionData) // NOTE: AND HERE WE USE THE DECODER ON DATA WITH DISCRIMINATOR
		err := instruction.UnmarshalWithDecoder(decoder)
		if err != nil {
			return nil, fmt.Errorf("failed to unmarshal instruction as InitInstruction: %w", err)
		}
		if accountIndicesData != nil && len(accountIndicesData) > 0 {
			indices, err := instruction.UnmarshalAccountIndices(accountIndicesData)
			if err != nil {
				return nil, fmt.Errorf("failed to unmarshal account indices: %w", err)
			}
			err = instruction.PopulateFromAccountIndices(indices, accountKeys)
			if err != nil {
				return nil, fmt.Errorf("failed to populate accounts: %w", err)
			}
		}
		return instruction, nil
```